### PR TITLE
Use -mode prefix just for the minor mode

### DIFF
--- a/0blayout.el
+++ b/0blayout.el
@@ -13,7 +13,7 @@
 ;; the buffers you left open before you switched (unless you closed it).
 
 ;; It doesn't require any setup at all more than:
-;; (0blayout)
+;; (0blayout-mode)
 
 ;; When you start emacs with 0blayout loaded, you will have a default layout
 ;; named "default", and then you can create new layouts (C-c C-l C-c), switch
@@ -136,7 +136,7 @@
 
 
 ;;;###autoload
-(define-minor-mode 0blayout
+(define-minor-mode 0blayout-mode
   "Handle layouts with ease"
   :lighter " 0bL"
   :global t


### PR DESCRIPTION
Sorry, I was a bit unclear about this; the mode itself still gets the `-mode` prefix, but the package/feature/file don't. :-)
