### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/0blayout.el
+++ b/0blayout.el
@@ -49,7 +49,8 @@
 ;;; Code:
 
 (defgroup 0blayout nil
-  "Configuration settings for 0blayout-mode.")
+  "Configuration settings for 0blayout-mode."
+  :group 'convenience)
 
 (defvar 0blayout-alist ()
   "List of the currently defined layouts.")

--- a/0blayout.el
+++ b/0blayout.el
@@ -57,6 +57,7 @@
 
 (defcustom 0blayout-default "default"
   "Name of default layout used."
+  :type 'string
   :group '0blayout)
 
 (defvar 0blayout-keys-map '(("C-c" . 0blayout-new)


### PR DESCRIPTION
Hi! Thanks to deverop such a great package!

I found below byte-compile warnings and fix them.

```
Compiling file /Users/conao/.emacs.d/local/26.2/elpa/0blayout-20161008.1507/0blayout.el at Wed Jul  3 03:41:10 2019
Entering directory ‘/Users/conao/.emacs.d/local/26.2/elpa/0blayout-20161008.1507/’
    0blayout.el:52:1:Warning: defgroup for ‘0blayout’ fails to specify containing group
    0blayout.el:58:1:Warning: defcustom for ‘0blayout-default’ fails to specify type
    0blayout.el:58:1:Warning: defcustom for ‘0blayout-default’ fails to specify type
```